### PR TITLE
Use u8::from_str_radix to convert base 16 to u8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,17 +154,17 @@ pub fn color_from_hex(input: TokenStream) -> TokenStream {
             for token in iter {
                 tokens.push(token);
 
-                if tokens.len() > 8 {
-                    panic!("expected a maximum of 8 characters for RGBA, ex: #4c4c4cff");
-                }
-            }
-
-            if tokens.len() < 6 {
-                panic!(
-                    "expected a minimum of 6 characters for RGB, ex: #4c4c4c. Tokens: {:#?}",
-                    tokens
+                assert!(
+                    tokens.len() <= 8,
+                    "expected a maximum of 8 characters for RGBA, ex: #4c4c4cff"
                 );
             }
+
+            assert!(
+                tokens.len() >= 6,
+                "expected a minimum of 6 characters for RGB, ex: #4c4c4c. Tokens: {:#?}",
+                tokens
+            );
 
             out_ts.extend(tokens.into_iter());
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,6 +11,7 @@ fn test_character_cases() {
     assert_eq!(color_from_hex!("a1 b2 c3 d4"), [0xA1, 0xB2, 0xC3, 0xD4]);
     assert_eq!(color_from_hex!("E5 E6 90 92"), [0xE5, 0xE6, 0x90, 0x92]);
     assert_eq!(color_from_hex!("0a0B 0C"), [10, 11, 12]);
+    assert_eq!(color_from_hex!("a2  	b9 c4 D 3"), [0xA2, 0xB9, 0xC4, 0xD3]);
 }
 
 #[test]


### PR DESCRIPTION
Use `u8::from_str_radix` to convert base 16 to u8. I think this makes the code clearer and a bit easier to read.