### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-color_hex = "0.2.0"
+color-hex = "0.2.0"
 ```
 
 Here is an example of converting a direct "HTML style" hex color string to an array:


### PR DESCRIPTION
Seems like you need to write color-hex and not color_hex on Cargo.toml.